### PR TITLE
Add Wayback Machine archive button for job listings

### DIFF
--- a/.github/scripts/update_readmes.py
+++ b/.github/scripts/update_readmes.py
@@ -11,7 +11,13 @@ def main():
 
     util.checkSchema(listings)
     filtered = util.filterListings(listings, earliest_date=1748761200)
-    
+
+    try:
+        util.archiveNewListings(filtered)
+        util.saveListingsToJSON(listings)
+    except Exception as e:
+        print(f"Wayback archiving step failed, continuing without it: {e}")
+
     util.sortListings(filtered)
     util.embedTable(filtered)
 

--- a/.github/scripts/update_readmes.py
+++ b/.github/scripts/update_readmes.py
@@ -14,9 +14,10 @@ def main():
 
     try:
         util.archiveNewListings(filtered)
-        util.saveListingsToJSON(listings)
     except Exception as e:
         print(f"Wayback archiving step failed, continuing without it: {e}")
+
+    util.saveListingsToJSON(listings)
 
     util.sortListings(filtered)
     util.embedTable(filtered)

--- a/.github/scripts/util.py
+++ b/.github/scripts/util.py
@@ -3,6 +3,9 @@ import re
 from datetime import date, datetime, timezone, timedelta
 import random
 import os
+import time
+import urllib.request
+import urllib.error
 
 # SIMPLIFY_BUTTON = "https://i.imgur.com/kvraaHg.png"
 SIMPLIFY_BUTTON = "https://i.imgur.com/MXdpmi0.png" # says apply
@@ -10,6 +13,13 @@ SHORT_APPLY_BUTTON = "https://i.imgur.com/fbjwDvo.png"
 SQUARE_SIMPLIFY_BUTTON = "https://i.imgur.com/aVnQdox.png"
 LONG_APPLY_BUTTON = "https://i.imgur.com/G5Bzlx3.png"
 INACTIVE_THRESHOLD_MONTHS = 4
+
+# Wayback Machine "Archived" button
+WAYBACK_LOGO = "https://archive.org/favicon.ico"
+WAYBACK_SAVE_URL = "https://web.archive.org/save/"
+WAYBACK_USER_AGENT = "New-Grad-Positions-Bot/1.0 (+https://github.com/SimplifyJobs/New-Grad-Positions)"
+WAYBACK_MAX_PER_RUN = 6
+WAYBACK_DELAY_SECONDS = 20
 
 # Set of Simplify company URLs to block from appearing in the README
 # Add Simplify company URLs to block them (e.g., "https://simplify.jobs/c/Jerry")
@@ -89,9 +99,16 @@ def getSponsorship(listing):
         return " 🇺🇸"
     return ""
 
+def getArchiveButton(listing):
+    wayback_url = listing.get("wayback_url")
+    if not wayback_url:
+        return ""
+    return f' <a href="{wayback_url}"><img src="{WAYBACK_LOGO}" width="16" height="16" alt="Archived" title="View on the Wayback Machine"></a>'
+
 def getLink(listing):
+    archive_button = getArchiveButton(listing)
     if not listing["active"]:
-        return "🔒"
+        return "🔒" + archive_button
     link = listing["url"]
     if "?" not in link:
         link += "?utm_source=Simplify&ref=Simplify"
@@ -100,13 +117,14 @@ def getLink(listing):
     # return f'<a href="{link}" style="display: inline-block;"><img src="{SHORT_APPLY_BUTTON}" width="160" alt="Apply"></a>'
 
     if listing["source"] != "Simplify":
-        return f'<a href="{link}"><img src="{LONG_APPLY_BUTTON}" width="100" alt="Apply"></a>'
-    
+        return f'<a href="{link}"><img src="{LONG_APPLY_BUTTON}" width="100" alt="Apply"></a>{archive_button}'
+
     simplifyLink = f"https://simplify.jobs/p/{listing['id']}?utm_source=GHList"
     return (
         f'<div align="center">'
         f'<a href="{link}"><img src="{SHORT_APPLY_BUTTON}" width="52" alt="Apply"></a> '
         f'<a href="{simplifyLink}"><img src="{SQUARE_SIMPLIFY_BUTTON}" width="28" alt="Simplify"></a>'
+        f'{archive_button}'
         f'</div>'
     )
     
@@ -254,6 +272,56 @@ def getListingsFromJSON(filename=".github/scripts/listings.json"):
         print("Recieved " + str(len(listings)) +
               " listings from listings.json")
         return listings
+
+def saveListingsToJSON(listings, filename=".github/scripts/listings.json"):
+    with open(filename, "w") as f:
+        json.dump(listings, f, indent=4)
+
+class WaybackRateLimited(Exception):
+    pass
+
+def save_to_wayback(url, timeout=15):
+    """Best-effort request asking the Wayback Machine to capture url now.
+    Returns the archived URL, or None if the capture couldn't be confirmed."""
+    request = urllib.request.Request(WAYBACK_SAVE_URL + url, headers={"User-Agent": WAYBACK_USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            content_location = response.headers.get("Content-Location")
+            if content_location:
+                return "https://web.archive.org" + content_location
+            if response.geturl().startswith("https://web.archive.org/web/"):
+                return response.geturl()
+            return None
+    except urllib.error.HTTPError as e:
+        if e.code == 429:
+            raise WaybackRateLimited()
+        print(f"Wayback: could not archive {url} (HTTP {e.code})")
+        return None
+    except Exception as e:
+        print(f"Wayback: could not archive {url} ({type(e).__name__}: {e})")
+        return None
+
+def archiveNewListings(listings, max_attempts=WAYBACK_MAX_PER_RUN, delay_seconds=WAYBACK_DELAY_SECONDS):
+    """Archive active listings that don't have a wayback_url yet until rate-limited.
+    Mutates listings in place. Stops early if the Wayback Machine rate-limits us."""
+    candidates = [l for l in listings if l.get("active") and not l.get("wayback_url")]
+    candidates.sort(key=lambda l: l["date_posted"], reverse=True)
+
+    archived_count = 0
+    for i, listing in enumerate(candidates[:max_attempts]):
+        if i > 0:
+            time.sleep(delay_seconds)
+        try:
+            wayback_url = save_to_wayback(listing["url"])
+        except WaybackRateLimited:
+            print("Wayback Machine rate-limited us, stopping archive attempts for this run")
+            break
+        if wayback_url:
+            listing["wayback_url"] = wayback_url
+            archived_count += 1
+
+    print(f"Archived {archived_count} listing(s) to the Wayback Machine this run")
+    return listings
 
 def create_category_table(listings, category_name):
     category_listings = [listing for listing in listings if listing["category"] == category_name]

--- a/.github/scripts/util.py
+++ b/.github/scripts/util.py
@@ -274,8 +274,16 @@ def getListingsFromJSON(filename=".github/scripts/listings.json"):
         return listings
 
 def saveListingsToJSON(listings, filename=".github/scripts/listings.json"):
-    with open(filename, "w") as f:
-        json.dump(listings, f, indent=4)
+    # Write to a temp file first so a failure mid-dump can't leave listings.json truncated
+    temp_filename = filename + ".tmp"
+    try:
+        with open(temp_filename, "w") as f:
+            json.dump(listings, f, indent=4)
+        os.replace(temp_filename, filename)
+    except Exception:
+        if os.path.exists(temp_filename):
+            os.remove(temp_filename)
+        raise
 
 class WaybackRateLimited(Exception):
     pass
@@ -283,14 +291,18 @@ class WaybackRateLimited(Exception):
 def save_to_wayback(url, timeout=15):
     """Best-effort request asking the Wayback Machine to capture url now.
     Returns the archived URL, or None if the capture couldn't be confirmed."""
-    request = urllib.request.Request(WAYBACK_SAVE_URL + url, headers={"User-Agent": WAYBACK_USER_AGENT})
+    # urllib drops any #fragment before sending, and Wayback hands back a
+    # fragment-less snapshot URL, so keep it aside and re-attach it to the result.
+    target, _, fragment = url.partition("#")
+    suffix = "#" + fragment if fragment else ""
+    request = urllib.request.Request(WAYBACK_SAVE_URL + target, headers={"User-Agent": WAYBACK_USER_AGENT})
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             content_location = response.headers.get("Content-Location")
             if content_location:
-                return "https://web.archive.org" + content_location
+                return "https://web.archive.org" + content_location + suffix
             if response.geturl().startswith("https://web.archive.org/web/"):
-                return response.geturl()
+                return response.geturl() + suffix
             return None
     except urllib.error.HTTPError as e:
         if e.code == 429:

--- a/.github/workflows/update_readmes.yml
+++ b/.github/workflows/update_readmes.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   run-python-script:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Why

- Job listings get taken down before people interview. Multiple people complain about this, the original job description (JD) is gone by the time they get an interview (and no one wants to ask for a copy of the JD, that may reflect poorly).
- An archive button gives a fallback snapshot via the Wayback Machine.
- MAYBE: once JDs are archived, could analyze them later. Example: most popular tech stacks by JD.

What this does

- Adds an "Archived" button next to Apply, in the Application column which links to the Wayback Machine snapshot of the listing.
- update_readmes.py/util.py archives a few (hardcoded, based on observed rate limit for anon requests) new active listings per run.
- wayback_url gets saved into listings.json.

Known limitations

- Some ATS apply routes don't expose the JD. Example: Workable /apply/ links, Ashby ?embed=true links. Needs more logic to detect and archive the real JD page.
- Archiving is best effort. If Wayback rate limits us, we stop for that run and try again next run.
  - MAYBE: Could use an async queue instead of live (capped) requests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SimplifyJobs/codesmith/New-Grad-Positions/pr/2971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791666876&installation_model_id=6807&pr_number=2971&repository=SimplifyJobs%2FNew-Grad-Positions&return_to=https%3A%2F%2Fgithub.com%2FSimplifyJobs%2FNew-Grad-Positions%2Fpull%2F2971&signature=eecf4ed4290fe5505706452c29af222d380372d9d1468849a7b2ee2f356c0b1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Wayback Machine archive button for job listings so interviewers can still view the original JD after it’s taken down, and best-effort archives new active listings each run.

**Details**
- Listings with a saved `wayback_url` show an “Archived” button next to Apply, including inactive listings.
- `update_readmes.py` archives up to 6 active listings without a snapshot per run via `web.archive.org/save/`, with a 20-second delay between requests.
- Archived URLs persist in `listings.json` so each listing is archived only once; writes go through a temp file + atomic replace to avoid truncation on failure.
- The README update workflow gets a 10-minute timeout to accommodate the archiving step.

**Known limitations**
- Some ATS apply routes (e.g., Workable `/apply/` links, Ashby `?embed=true` links) don’t expose the actual JD page, so the snapshot may not capture the real content.
- Archiving is best effort; if the Wayback Machine rate-limits (HTTP 429), archiving stops for that run but the rest of the pipeline continues.

<sup>Written for commit 1bc4dfcde611b47a0795e613d7928762880b5048. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SimplifyJobs/New-Grad-Positions/pull/2971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

